### PR TITLE
Fix duplicate vaccine rows

### DIFF
--- a/plugins/polio/js/src/forms/RoundVaccinesForm.tsx
+++ b/plugins/polio/js/src/forms/RoundVaccinesForm.tsx
@@ -207,7 +207,7 @@ export const RoundVaccinesForm: FunctionComponent<Props> = ({
 
     return (
         <>
-            {vaccines.length > 0 &&
+            {vaccines.length > 1 &&
                 vaccines.map((_vaccine, index) => {
                     return (
                         <RoundVaccineForm


### PR DESCRIPTION
## Summary
- ensure only a single row displays when there is one vaccine

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest` *(fails: command not found)*
- `npm test` *(fails: mocha not found)*